### PR TITLE
fix typos in SMTP config

### DIFF
--- a/templates/gitlab_email.j2
+++ b/templates/gitlab_email.j2
@@ -49,8 +49,8 @@
     gitlab_rails['smtp_openssl_verify_mode'] = {{ gitlab_smtp_openssl_verify_mode | lower }}
 {% endif %}
 {% if gitlab_smtp_ca_path is defined -%}
-    gilab_rails['smtp_ca_path'] = "{{ gitlab_smtp_ca_path}}"
+    gitlab_rails['smtp_ca_path'] = "{{ gitlab_smtp_ca_path}}"
 {% endif %}
 {% if gitlab_smtp_ca_file is defined -%}
-    gilab_rails['smtp_ca_file'] = "{{ gitlab_smtp_ca_file}}"
+    gitlab_rails['smtp_ca_file'] = "{{ gitlab_smtp_ca_file}}"
 {% endif %}


### PR DESCRIPTION
Hi, I noticed this when setting up SMTP. Before fixing the typos, `gitlab-ctl reconfigure` failed with `NoMethodError`.
