### PR TITLE
Improve support for Debian derivatives

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -179,8 +179,9 @@ gitlab_version_suffix: "-ce.0"    # Only used for Debian and if gitlab_version i
 
 # --- GitLab email server settings --- #
 ## see https://gitlab.com/gitlab-org/omnibus-gitlab/blob/629def0a7a26e7c2326566f0758d4a27857b52a3/doc/settings/smtp.md#smtp-settings
-## Use smtp instead of sendmail/postfix.
+## Use remote smtp server instead of local (sendmail/postfix).
 # gitlab_smtp_enable: True
+# gitlab_smtp_service: postfix
 # gitlab_smtp_address: "smtp.server"
 # gitlab_smtp_port: 456
 # gitlab_smtp_user_name: "smtp user"

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -12,6 +12,10 @@ galaxy_info:
       - 6
       - 7
 
+  - name: Debian
+    versions:
+      - jessie
+
   - name: Ubuntu
     versions:
       - precise

--- a/tasks/install-Debian.yml
+++ b/tasks/install-Debian.yml
@@ -6,6 +6,10 @@
     - gitlab
     - gitlab-gpg
 
+- name: DEBIAN | Install apt-transport-https
+  apt:
+    name: apt-transport-https
+
 - name: DEBIAN | Install support packages
   apt:
     name: "{{ item }}"

--- a/tasks/install-Debian.yml
+++ b/tasks/install-Debian.yml
@@ -14,7 +14,7 @@
   with_items:
       - curl
       - ca-certificates
-      - postfix
+      - "{{ gitlab_smtp_service }}"
   tags:
     - gitlab
     - gitlab-packages

--- a/tasks/install-RedHat.yml
+++ b/tasks/install-RedHat.yml
@@ -13,7 +13,7 @@
     state: latest
   with_items:
     - curl
-    - postfix
+    - "{{ gitlab_smtp_service }}"
     - cronie
   tags:
     - gitlab

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -38,9 +38,9 @@
 - { include: install-RedHat.yml, when: 'ansible_os_family == "RedHat"'}
 - { include: install-Debian.yml, when: 'ansible_os_family == "Debian"'}
 
-- name: Start and enable postfix
+- name: Start and enable mail
   service:
-    name: postfix
+    name: "{{ gitlab_smtp_service }}"
     enabled: yes
     state: started
   tags:

--- a/templates/gitlab-ce.list.j2
+++ b/templates/gitlab-ce.list.j2
@@ -1,4 +1,4 @@
 # the repository at https://packages.gitlab.com/gitlab/gitlab-ce
 
-deb https://packages.gitlab.com/gitlab/gitlab-ce/ubuntu/ {{ ansible_distribution_release }} main
-deb-src https://packages.gitlab.com/gitlab/gitlab-ce/ubuntu/ {{ ansible_distribution_release }} main
+deb https://packages.gitlab.com/gitlab/gitlab-ce/{{ ansible_distribution|lower }}/ {{ ansible_distribution_release }} main
+deb-src https://packages.gitlab.com/gitlab/gitlab-ce/{{ ansible_distribution|lower }}/ {{ ansible_distribution_release }} main

--- a/tests/Vagrantfile
+++ b/tests/Vagrantfile
@@ -27,9 +27,21 @@ Vagrant.configure(2) do |config|
     end
   end
 
+  # Debian 8 (Jessie)
+  config.vm.define "deb8" do |deb8|
+    deb8.vm.box = "debian/jessie64"
+    deb8.vm.network "forwarded_port", guest: 80, host: 8084
+    deb8.vm.network "forwarded_port", guest: 443, host: 8446
+    deb8.vm.hostname = "gitlab-deb8.vagrant.dev"
+    config.vm.provider "virtualbox" do |vbox|
+      vbox.memory = 2048
+      vbox.cpus = 2
+    end
+  end
+
   # Ubuntu 12.04
   config.vm.define "ub12" do |ub12|
-    ub12.vm.box = "geerlingguy/ubuntu1204"
+    ub12.vm.box = "ubuntu/precise64"
     ub12.vm.network "forwarded_port", guest: 80, host: 8082
     ub12.vm.network "forwarded_port", guest: 443, host: 8445
     ub12.vm.hostname = "gitlab-ub12.vagrant.dev"
@@ -41,7 +53,7 @@ Vagrant.configure(2) do |config|
 
   # Ubuntu 14.04
   config.vm.define "ub14" do |ub14|
-    ub14.vm.box = "geerlingguy/ubuntu1404"
+    ub14.vm.box = "ubuntu/trusty64"
     ub14.vm.network "forwarded_port", guest: 80, host: 8084
     ub14.vm.network "forwarded_port", guest: 443, host: 8446
     ub14.vm.hostname = "gitlab-ub14.vagrant.dev"

--- a/tests/vagrant.yml
+++ b/tests/vagrant.yml
@@ -2,7 +2,7 @@
   remote_user: vagrant
   become: yes
   roles:
-    - gitlab
+    - samdoran.gitlab
 
   vars:
     # gitlab_version: "8.6.9"

--- a/tests/vagrant.yml
+++ b/tests/vagrant.yml
@@ -2,7 +2,7 @@
   remote_user: vagrant
   become: yes
   roles:
-    - samdoran.gitlab
+    - gitlab
 
   vars:
     # gitlab_version: "8.6.9"

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,5 +1,6 @@
 gitlab_repo_dir: /etc/apt/sources.list.d
 gitlab_repo_file: gitlab-ce.list
+gitlab_smtp_service: exim4
 gitlab_check_command: 'dpkg-query'
 
 gitlab_nginx_ssl_cert_path: /etc/ssl/certs

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,6 +1,7 @@
 gitlab_repo_dir: /etc/yum.repos.d
 gitlab_repo_file: gitlab-ce.repo
 gitlab_check_command: 'rpm -q'
+gitlab_smtp_service: postfix
 
 gitlab_nginx_ssl_cert_path: /etc/pki/tls/certs
 gitlab_nginx_ssl_key_path: /etc/pki/tls/private


### PR DESCRIPTION
- Debian derivatives use exim4 not postfix by default for their local mail transport, I _think_ there's no reason why this gitlab should be tied to postfix?
- the modification to `templates/gitlab-ce.list.j2` means we can support Debian as well as Ubuntu
- update the Vagrantfile to use official Ubuntu Vagrant boxes
