### PR TITLE
Self signed SSL Certificate option

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Here are the variables you will most likely need to set.
 | `gitlab_nginx_ssl_crt` | Undefined multi-line variable | SSL Public certificate. |
 | `gitlab_nginx_ssl_key` | Undefined multi-line variable | SSL Private key. I recommend putting this in an ansible vault. |
 |`gitlab_ssl_self_sign`| False | Wether or not to generate a self signed SSL Certificate. Do not provide an SSL Certificate if using this option. |
-|`gitlab_ssl_self_sign_subj` | /CN={{ ansible_fqdn }} | Subject of self signed SSL Certificate. |
+|`gitlab_ssl_self_sign_subj` | `"/CN={{ ansible_fqdn }}"` | Subject of self signed SSL Certificate. |
 |`gitlab_ssl_self_sign_days`| 365 | Days self signed SSL Certificate is signed for. | 
 
 #### GitLab CI Variables ####

--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ Here are the variables you will most likely need to set.
 | `gitlab_nginx_ssl_port` | 443 | Listening port for HTTPS. |
 | `gitlab_nginx_ssl_crt` | Undefined multi-line variable | SSL Public certificate. |
 | `gitlab_nginx_ssl_key` | Undefined multi-line variable | SSL Private key. I recommend putting this in an ansible vault. |
+|`gitlab_ssl_self_sign`| False | Wether or not to generate a self signed SSL Certificate. Do not provide an SSL Certificate if using this option. |
+|`gitlab_ssl_self_sign_subj` | /CN={{ ansible_fqdn }} | Subject of self signed SSL Certificate. |
+|`gitlab_ssl_self_sign_days`| 365 | Days self signed SSL Certificate is signed for. | 
 
 #### GitLab CI Variables ####
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,6 +6,8 @@ gitlab_days_old_backups: 10
 gitlab_fqdn: "{{ ansible_fqdn }}"
 gitlab_nginx_ssl_enabled: False
 gitlab_ssl_self_sign: False
+gitlab_ssl_self_sign_subj: "/CN={{ansible_fqdn}}"
+gitlab_ssl_self_sign_days: 365
 gitlab_nginx_ssl_filename: "{{ ansible_fqdn }}"
 gitlab_nginx_ssl_certificate_path: "{{ gitlab_nginx_ssl_cert_path }}/{{ gitlab_nginx_ssl_filename }}.crt"
 gitlab_nginx_ssl_certificate_key_path: "{{ gitlab_nginx_ssl_key_path }}/{{ gitlab_nginx_ssl_filename }}.key"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,7 +6,7 @@ gitlab_days_old_backups: 10
 gitlab_fqdn: "{{ ansible_fqdn }}"
 gitlab_nginx_ssl_enabled: False
 gitlab_ssl_self_sign: False
-gitlab_ssl_self_sign_subj: "/CN={{ansible_fqdn}}"
+gitlab_ssl_self_sign_subj: "/CN={{ ansible_fqdn }}"
 gitlab_ssl_self_sign_days: 365
 gitlab_nginx_ssl_filename: "{{ ansible_fqdn }}"
 gitlab_nginx_ssl_certificate_path: "{{ gitlab_nginx_ssl_cert_path }}/{{ gitlab_nginx_ssl_filename }}.crt"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,6 +5,7 @@ gitlab_days_old_backups: 10
 # More options are available in the GitLab Nginx section
 gitlab_fqdn: "{{ ansible_fqdn }}"
 gitlab_nginx_ssl_enabled: False
+gitlab_ssl_self_sign: False
 gitlab_nginx_ssl_filename: "{{ ansible_fqdn }}"
 gitlab_nginx_ssl_certificate_path: "{{ gitlab_nginx_ssl_cert_path }}/{{ gitlab_nginx_ssl_filename }}.crt"
 gitlab_nginx_ssl_certificate_key_path: "{{ gitlab_nginx_ssl_key_path }}/{{ gitlab_nginx_ssl_filename }}.key"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -61,6 +61,41 @@
     - gitlabrb
     - ssl
 
+- name: Generate temp cert key
+  command: openssl genrsa -des3 -passout pass:x -out /tmp/server.pass.key 2048
+  when: gitlab_ssl_self_sign
+  tags:
+    - gitlab-self-signed
+
+- name: Generate self signed server key
+  command: >
+    openssl rsa -passin pass:x -in /tmp/server.pass.key -out 
+    {{ gitlab_nginx_ssl_cert_path }}/{{ gitlab_nginx_ssl_filename }}.key
+  when: gitlab_ssl_self_sign
+  creates: "{{ gitlab_nginx_ssl_cert_path }}/{{ gitlab_nginx_ssl_filename }}.key"
+  tags:
+    - gitlab-self-signed
+
+- name: Generate csr
+  command: > 
+    openssl req -new -key {{ gitlab_nginx_ssl_cert_path }}/{{ gitlab_nginx_ssl_filename }}.key 
+    -out /tmp/server.csr -subj {{ gitlab_ssl_self_sign_subj }}
+  when: gitlab_ssl_self_sign
+  creates: /tmp/server.csr
+  tags:
+    - gitlab-self-signed
+
+- name: Generate self signed certificate
+  command: >
+    openssl x509 -req -days {{ gitlab_ssl_self_sign_days }} 
+    -in /tmp/server.csr -signkey {{ gitlab_nginx_ssl_cert_path }}/{{ gitlab_nginx_ssl_filename }}.key 
+    -out {{ gitlab_nginx_ssl_cert_path }}/{{ gitlab_nginx_ssl_filename }}.crt
+  creates: "{{ gitlab_nginx_ssl_cert_path }}/{{ gitlab_nginx_ssl_filename }}.crt"
+  when: gitlab_ssl_self_sign
+  tags:
+    - gitlab-self-signed
+
+
 - name: Copy GitLab SSL certificate
   template:
     backup: yes

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -69,9 +69,9 @@
   command: >
     openssl rsa -passin pass:x -in /tmp/server.pass.key -out 
     {{ gitlab_nginx_ssl_key_path }}/{{ gitlab_nginx_ssl_filename }}.key
-  when: gitlab_ssl_self_sign
   args:
     creates: "{{ gitlab_nginx_ssl_key_path }}/{{ gitlab_nginx_ssl_filename }}.key"
+  when: gitlab_ssl_self_sign
 
 - name: Generate csr
   command: > 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -64,36 +64,31 @@
 - name: Generate temp cert key
   command: openssl genrsa -des3 -passout pass:x -out /tmp/server.pass.key 2048
   when: gitlab_ssl_self_sign
-  tags:
-    - gitlab-self-signed
 
 - name: Generate self signed server key
   command: >
     openssl rsa -passin pass:x -in /tmp/server.pass.key -out 
-    {{ gitlab_nginx_ssl_cert_path }}/{{ gitlab_nginx_ssl_filename }}.key
+    {{ gitlab_nginx_ssl_key_path }}/{{ gitlab_nginx_ssl_filename }}.key
   when: gitlab_ssl_self_sign
-  creates: "{{ gitlab_nginx_ssl_cert_path }}/{{ gitlab_nginx_ssl_filename }}.key"
-  tags:
-    - gitlab-self-signed
+  args:
+    creates: "{{ gitlab_nginx_ssl_key_path }}/{{ gitlab_nginx_ssl_filename }}.key"
 
 - name: Generate csr
   command: > 
-    openssl req -new -key {{ gitlab_nginx_ssl_cert_path }}/{{ gitlab_nginx_ssl_filename }}.key 
+    openssl req -new -key {{ gitlab_nginx_ssl_key_path }}/{{ gitlab_nginx_ssl_filename }}.key 
     -out /tmp/server.csr -subj {{ gitlab_ssl_self_sign_subj }}
+  args:
+    creates: /tmp/server.csr
   when: gitlab_ssl_self_sign
-  creates: /tmp/server.csr
-  tags:
-    - gitlab-self-signed
 
 - name: Generate self signed certificate
   command: >
     openssl x509 -req -days {{ gitlab_ssl_self_sign_days }} 
-    -in /tmp/server.csr -signkey {{ gitlab_nginx_ssl_cert_path }}/{{ gitlab_nginx_ssl_filename }}.key 
+    -in /tmp/server.csr -signkey {{ gitlab_nginx_ssl_key_path }}/{{ gitlab_nginx_ssl_filename }}.key 
     -out {{ gitlab_nginx_ssl_cert_path }}/{{ gitlab_nginx_ssl_filename }}.crt
-  creates: "{{ gitlab_nginx_ssl_cert_path }}/{{ gitlab_nginx_ssl_filename }}.crt"
+  args:
+    creates: "{{ gitlab_nginx_ssl_cert_path }}/{{ gitlab_nginx_ssl_filename }}.crt"
   when: gitlab_ssl_self_sign
-  tags:
-    - gitlab-self-signed
 
 
 - name: Copy GitLab SSL certificate


### PR DESCRIPTION
I think a self signed certificate option would be super helpful when using this role for bootstrapping new environments. It provides way more security than just setting gitlab up with http only.

I added 3 variables:
gitlab_ssl_self_sign (False) - If "True" creates the self signed cert.
gitlab_ssl_self_sign_subj ("/CN={{ ansible_fqdn }}") - Subject string for openssl certificate generation.
gitlab_ssl_self_sign_days (365) - Days certificate is signed for.

I also added the process to generate a self signed certificate.